### PR TITLE
Add `fromUtf8` builtin

### DIFF
--- a/patches/from_utf8.patch
+++ b/patches/from_utf8.patch
@@ -1,0 +1,69 @@
+diff --git a/src/builtins/builtins-definitions.h b/src/builtins/builtins-definitions.h
+index 18da8a651b..3d33e33cb6 100644
+--- a/src/builtins/builtins-definitions.h
++++ b/src/builtins/builtins-definitions.h
+@@ -980,6 +980,7 @@ namespace internal {
+   TFJ(TypedArrayBaseConstructor, kJSArgcReceiverSlots, kReceiver)              \
+   TFJ(TypedArrayConstructor, kDontAdaptArgumentsSentinel)                      \
+   CPP(TypedArrayPrototypeBuffer)                                               \
++  CPP(TypedArrayUtf8String)                                                    \
+   /* ES6 #sec-get-%typedarray%.prototype.bytelength */                         \
+   TFJ(TypedArrayPrototypeByteLength, kJSArgcReceiverSlots, kReceiver)          \
+   /* ES6 #sec-get-%typedarray%.prototype.byteoffset */                         \
+diff --git a/src/builtins/builtins-typed-array.cc b/src/builtins/builtins-typed-array.cc
+index 4d41333588..aa27d41a4b 100644
+--- a/src/builtins/builtins-typed-array.cc
++++ b/src/builtins/builtins-typed-array.cc
+@@ -24,6 +24,36 @@ BUILTIN(TypedArrayPrototypeBuffer) {
+   return *typed_array->GetBuffer();
+ }
+ 
++BUILTIN(TypedArrayUtf8String) {
++  HandleScope scope(isolate);
++
++  Handle<JSTypedArray> typed_array;
++  bool ignore_bom = false;
++  int offset = 0;
++
++  const char* method_name = "fromUtf8";
++  ASSIGN_RETURN_FAILURE_ON_EXCEPTION(
++      isolate, typed_array,
++      JSTypedArray::Validate(isolate, args.atOrUndefined(isolate, 1), method_name));
++
++  ignore_bom = args.length() > 2 && Object::BooleanValue(*args.at<Object>(2), isolate);
++
++  auto buffer = typed_array->GetBuffer();
++  auto len = buffer->byte_length();
++  const uint8_t* bs = (const uint8_t*)buffer->backing_store();
++  
++  if (!ignore_bom && 
++      len >= 3 &&
++      (*bs) == 0xEF &&
++      *(bs + 1) == 0xBB &&
++      *(bs + 2) == 0xBF) {
++    offset += 3;
++  }
++
++  RETURN_RESULT_OR_FAILURE(
++      isolate, isolate->factory()->NewStringFromUtf8(base::Vector<const char>((const char*)(bs + offset), len - offset)));
++}
++
+ namespace {
+ 
+ int64_t CapRelativeIndex(Handle<Object> num, int64_t minimum, int64_t maximum) {
+diff --git a/src/init/bootstrapper.cc b/src/init/bootstrapper.cc
+index 2beaf45b14..aa4386ec66 100644
+--- a/src/init/bootstrapper.cc
++++ b/src/init/bootstrapper.cc
+@@ -3446,6 +3446,11 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
+     // TODO(caitp): alphasort accessors/methods
+     SimpleInstallFunction(isolate_, prototype, "at",
+                           Builtin::kTypedArrayPrototypeAt, 1, true);
++
++    // Deno-specific methods. See deno_core/01_core.js
++    SimpleInstallFunction(isolate_, global, "fromUtf8",
++                          Builtin::kTypedArrayUtf8String, 1, false);
++
+     SimpleInstallFunction(isolate_, prototype, "copyWithin",
+                           Builtin::kTypedArrayPrototypeCopyWithin, 2, false);
+     SimpleInstallFunction(isolate_, prototype, "every",


### PR DESCRIPTION
2x faster than `op_encoding_decode` in Deno for small UTF-8 strings.

```
divy@mini ~/g/deno (v8_fast_decode)> deno run -A bench.js
fromUtf8: Hello 😃
cpu: unknown
runtime: deno 1.36.4 (aarch64-apple-darwin)

benchmark      time (avg)             (min … max)    
--------------------------------------------------
            122.27 ns/iter  (122.02 ns … 215.82 ns)  

divy@mini ~/g/deno (v8_fast_decode)> target/release/deno run -A bench.js
fromUtf8: Hello 😃
cpu: unknown
runtime: deno 1.36.4 (aarch64-apple-darwin)

benchmark      time (avg)             (min … max)       
---------------------------------------------------
            64.02 ns/iter  (62.81 ns … 139.55 ns) 
```