### PR TITLE
Add patch: apply V8_TLS_USED_IN_LIBRARY to V8 internal_config

### DIFF
--- a/autoroll.ts
+++ b/autoroll.ts
@@ -1,5 +1,6 @@
 const V8_VERSIONS = [
   "14.9",
+  "14.7",
 ];
 
 const checkVersions = !!Deno.env.get("CHECK_V8_VERSIONS");

--- a/patches/0003-Apply-V8_TLS_USED_IN_LIBRARY-to-internal_config.patch
+++ b/patches/0003-Apply-V8_TLS_USED_IN_LIBRARY-to-internal_config.patch
@@ -1,22 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Leo Kettmeir <leo@deno.com>
-Date: Wed, 23 Apr 2026 00:00:00 +0000
-Subject: [PATCH] Apply V8_TLS_USED_IN_LIBRARY to internal_config
+From ee882db8c7ac05e1b022d0384fa5dd2ead7178b4 Mon Sep 17 00:00:00 2001
+From: Leo Kettmeir <crowlkats@toaxl.com>
+Date: Thu, 23 Apr 2026 17:31:21 +0200
+Subject: [PATCH] Apply V8_TLS_USED_IN_LIBRARY define to V8 internal_config
 
-The `v8_monolithic_for_shared_library` GN arg is meant to opt V8 into a
-shared-library-safe TLS model so its `thread_local` variables don't emit
-`local-exec` relocations (R_X86_64_TPOFF32 against `g_current_isolate_`
-etc.) that fail to link into a downstream cdylib.
+V8 already declares the `v8_monolithic_for_shared_library` GN arg, but
+the only place it adds the `V8_TLS_USED_IN_LIBRARY` define is the
+`:features` config -- which is consumed only by external embedders, not
+by the `internal_config` that V8's own `.cc` files use. As a result, V8
+internal sources (where the `thread_local Isolate*` etc. live) keep
+their `local-exec` TLS model and emit `R_X86_64_TPOFF32` relocations
+that fail to link into a downstream cdylib/.so on Linux.
 
-It already added the `V8_TLS_USED_IN_LIBRARY` define in `:features`, but
-that config is only consumed by external embedders (e.g. rusty_v8's
-`rusty_v8_config`) -- it isn't pulled in by `internal_config`, which is
-what V8's own `.cc` files use. The TLS variables themselves live in V8
-internal sources (`src/execution/isolate.cc` etc.), so they were never
-seeing the define and stayed in `local-exec` mode.
-
-Fix: add the same define to `internal_config` under the same arg, and
-drop the redundant `v8_monolithic &&` part of the existing `:features`
+Add the same define to `internal_config` under the same arg, and drop
+the redundant `v8_monolithic &&` part of the existing `:features`
 condition (the arg already implies its scope).
 ---
  BUILD.gn | 10 +++++++++-
@@ -29,7 +25,7 @@ index a5c7d847781..75e45b2429b 100644
 @@ -897,6 +897,14 @@ config("internal_config") {
      defines += [ "BUILDING_V8_SHARED" ]
    }
-
+ 
 +  # When the resulting V8 archive will be linked into a shared library
 +  # downstream (e.g. a cdylib), thread-locals defined in V8 internal sources
 +  # must use a TLS model compatible with -fPIC (not "local-exec"). This
@@ -44,11 +40,12 @@ index a5c7d847781..75e45b2429b 100644
 @@ -1229,7 +1237,7 @@ config("features") {
      defines += [ "CPPGC_ALLOW_ALLOCATIONS_IN_PREFINALIZERS" ]
    }
-
+ 
 -  if (v8_monolithic && v8_monolithic_for_shared_library) {
 +  if (v8_monolithic_for_shared_library) {
      defines += [ "V8_TLS_USED_IN_LIBRARY" ]
    }
+ 
+-- 
+2.53.0
 
---
-2.37.3

--- a/patches/0003-Apply-V8_TLS_USED_IN_LIBRARY-to-internal_config.patch
+++ b/patches/0003-Apply-V8_TLS_USED_IN_LIBRARY-to-internal_config.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Leo Kettmeir <leo@deno.com>
+Date: Wed, 23 Apr 2026 00:00:00 +0000
+Subject: [PATCH] Apply V8_TLS_USED_IN_LIBRARY to internal_config
+
+The `v8_monolithic_for_shared_library` GN arg is meant to opt V8 into a
+shared-library-safe TLS model so its `thread_local` variables don't emit
+`local-exec` relocations (R_X86_64_TPOFF32 against `g_current_isolate_`
+etc.) that fail to link into a downstream cdylib.
+
+It already added the `V8_TLS_USED_IN_LIBRARY` define in `:features`, but
+that config is only consumed by external embedders (e.g. rusty_v8's
+`rusty_v8_config`) -- it isn't pulled in by `internal_config`, which is
+what V8's own `.cc` files use. The TLS variables themselves live in V8
+internal sources (`src/execution/isolate.cc` etc.), so they were never
+seeing the define and stayed in `local-exec` mode.
+
+Fix: add the same define to `internal_config` under the same arg, and
+drop the redundant `v8_monolithic &&` part of the existing `:features`
+condition (the arg already implies its scope).
+---
+ BUILD.gn | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index a5c7d847781..75e45b2429b 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -897,6 +897,14 @@ config("internal_config") {
+     defines += [ "BUILDING_V8_SHARED" ]
+   }
+
++  # When the resulting V8 archive will be linked into a shared library
++  # downstream (e.g. a cdylib), thread-locals defined in V8 internal sources
++  # must use a TLS model compatible with -fPIC (not "local-exec"). This
++  # define switches them via src/common/thread-local-storage.h.
++  if (v8_monolithic_for_shared_library) {
++    defines += [ "V8_TLS_USED_IN_LIBRARY" ]
++  }
++
+   if (v8_current_cpu == "riscv64" || v8_current_cpu == "riscv32") {
+     if (!is_clang) {
+       libs = [ "atomic" ]
+@@ -1229,7 +1237,7 @@ config("features") {
+     defines += [ "CPPGC_ALLOW_ALLOCATIONS_IN_PREFINALIZERS" ]
+   }
+
+-  if (v8_monolithic && v8_monolithic_for_shared_library) {
++  if (v8_monolithic_for_shared_library) {
+     defines += [ "V8_TLS_USED_IN_LIBRARY" ]
+   }
+
+--
+2.37.3


### PR DESCRIPTION
## Summary

Adds a new floated patch (`patches/0003-...`) that fixes a V8 build-system bug surfacing when rusty_v8's archive is linked into a downstream `cdylib`/`.so` on Linux.

V8 already declares `v8_monolithic_for_shared_library` as a GN arg, but the only place it adds the `V8_TLS_USED_IN_LIBRARY` define is the `:features` config -- which is consumed only by external embedders, **not** by the `internal_config` that V8's own `.cc` files use. So V8 internal sources (where `thread_local Isolate* g_current_isolate_` etc. live) stay in `local-exec` TLS model and emit `R_X86_64_TPOFF32` relocations:

```
rust-lld: error: relocation R_X86_64_TPOFF32 against v8::internal::g_current_isolate_
  cannot be used with -shared
```

This breaks `V8_FROM_SOURCE=1 cargo build` for any downstream that links rusty_v8 into a shared library (e.g. Deno's `denort_desktop` cdylib).

## Patch contents

- Add `defines += [ "V8_TLS_USED_IN_LIBRARY" ]` to `config("internal_config")` under `if (v8_monolithic_for_shared_library)`.
- Drop the redundant `v8_monolithic &&` part of the existing `:features` condition (the arg's name already implies the scope, and requiring `v8_monolithic` excludes us since rusty_v8 doesn't build the `v8_monolith` static lib target).

## Companion PR

denoland/rusty_v8#1970 will start passing `v8_monolithic_for_shared_library=true` once this lands and gets rolled into the next `14.7-lkgr-denoland` autoroll.

## Test plan

- [ ] Verify autoroll picks up the new patch and applies cleanly to `14.7-lkgr-denoland`.
- [ ] After the rusty_v8 companion PR lands, verify `V8_FROM_SOURCE=1 cargo build` of Deno's `denort_desktop` cdylib succeeds on Linux.